### PR TITLE
Use r.dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ from requirements import r
 setup(
     name='your-package',
     version='0.0.1',
-    **r.requirements)
+    **r.dependencies)
 ```
 
 ### Features


### PR DESCRIPTION
Use `r.dependencies` instead of `r.requirements`, as is noted in issue #4.
